### PR TITLE
Multilingual fixes

### DIFF
--- a/chopro_epub/cli/epub.py
+++ b/chopro_epub/cli/epub.py
@@ -24,8 +24,10 @@
 import codecs
 import logging
 import sys
+import re
 from pathlib import Path
 from typing import Optional
+from unidecode import unidecode
 
 import typer
 from ebooklib import epub
@@ -40,6 +42,11 @@ else:
     # importlib.resources has files(), so use that:
     import importlib.resources as importlib_resources
 
+def fix_filename(name: str) -> str:
+    name = unidecode(name)
+    name = re.sub(r'\s+', '_', name)
+    name = re.sub(r'[^a-zA-Z0-9_.-]+', '', name)
+    return name
 
 @typer.run
 def main(
@@ -66,7 +73,6 @@ def main(
     """Generate an EPUB songbook from a list of songs."""
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
     song_skeleton = """<h3>{0} ({1})</h3>{2}"""
-    remove_punctuation_map = dict((ord(char), None) for char in r'\/*?:"<>|')
 
     ### Starting script per say
     book = epub.EpubBook()
@@ -96,7 +102,7 @@ def main(
             body, title, artist = chordpro2html(file.read(), wrap_chords=wrap_chords)
 
         song_title = f"{title} ({artist})"
-        song_filename = f"{title}_{artist}.xhtml".translate(remove_punctuation_map)
+        song_filename = fix_filename(f"{title}_{artist}.xhtml")
         chapter = epub.EpubHtml(
             title=song_title,
             file_name=song_filename,

--- a/chopro_epub/parser.py
+++ b/chopro_epub/parser.py
@@ -153,7 +153,7 @@ def chordpro2html(song: str, wrap_chords: bool = True) -> str:
 
     # lyricCharSet = pp.alphanums+pp.alphas8bit+",-_:;.!?#+*^°§$%&/|()='`´\\\"\t "
     # everything but "{}[]"
-    lyric_char_set = pp.pyparsing_unicode.Latin1.printables + "\t "
+    lyric_char_set = pp.pyparsing_unicode.BasicMultilingualPlane.printables + "\t "
     chord_char_set = pp.alphanums + " -#(%)/='`´."
 
     cmd = pp.oneOf("title t artist a")

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     pyparsing
     ebooklib
     typer
+    unidecode
     importlib-resources>=1.1.0; python_version < '3.9'
 
 [options.package_data]


### PR DESCRIPTION
This PR addresses two issues related to non-latin characters:

1. Update the parser to accept non-latin printable characters instead of ignoring song lines that contain them
2. Update the method for sanitizing filenames that go into the epub archive to make use of [unidecode](https://pypi.org/project/Unidecode/) in order to convert non-ASCII characters to ASCII for use within the filename

Thank you for maintaining this software - it's a great tool!